### PR TITLE
Issue #12: PhiremockProcess::isPcntlEnabled always returns false and triggers warning

### DIFF
--- a/src/Extension/PhiremockProcess.php
+++ b/src/Extension/PhiremockProcess.php
@@ -136,6 +136,6 @@ class PhiremockProcess
      */
     private function isPcntlEnabled()
     {
-        return !$this->isWindows() && defined(SIGTERM);
+        return !$this->isWindows() && defined('SIGTERM');
     }
 }


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock-codeception-extension/issues/12

Tests result:
```
[user@localhost phiremock-codeception-extension]$ vendor/codeception/codeception/codecept -c tests/ run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.

Acceptance Tests (1) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /home/denis/Work/SAP/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
✔ BasicTestCest: Try to test (0.10s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /home/denis/Work/SAP/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /home/denis/Work/SAP/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /home/denis/Work/SAP/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /home/denis/Work/SAP/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /home/denis/Work/SAP/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276


Time: 3.77 seconds, Memory: 12.00MB

OK (1 test, 1 assertion)
```