### PR TITLE
Issue #14: Add ability to reset requests counter

### DIFF
--- a/src/Module/Phiremock.php
+++ b/src/Module/Phiremock.php
@@ -67,6 +67,11 @@ class Phiremock extends CodeceptionModule
         $this->phiremock->resetScenarios();
     }
 
+    public function haveCleanRequestsCounterInRemoteService()
+    {
+        $this->phiremock->resetRequestsCounter();
+    }
+
     public function seeRemoteServiceReceived($times, RequestBuilder $builder)
     {
         $requests = $this->phiremock->countExecutions($builder);

--- a/tests/tests/acceptance/BasicTestCest.php
+++ b/tests/tests/acceptance/BasicTestCest.php
@@ -30,5 +30,7 @@ class BasicTestCest
         $response = file_get_contents('http://localhost:18080/some/url');
         $I->assertEquals('I am a response', $response);
         $I->seeRemoteServiceReceived(1, A::getRequest()->andUrl(Is::equalTo('/some/url')));
+        $I->haveCleanRequestsCounterInRemoteService();
+        $I->seeRemoteServiceReceived(0, A::getRequest()->andUrl(Is::equalTo('/some/url')));
     }
 }


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock-codeception-extension/issues/14

Test resulsts:
```
$ vendor/bin/codecept -c tests run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.

Acceptance Tests (1) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
✔ BasicTestCest: Try to test (0.09s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276


Time: 3.77 seconds, Memory: 12.00MB

OK (1 test, 1 assertion)
````
P.S. I see some mistatch in naming, methods:
```
$I->expectARequestToRemoteServiceWithAResponse();
$I->haveACleanSetupInRemoteService();
```
have an "a" article, and methods
```
$I->dontExpectRequestsInRemoteService();
$I->haveCleanScenariosInRemoteService();
$I->seeRemoteServiceReceived():
```
are clean. Will some methods names be changed?