### PR TITLE
Issue #16: Log file is not created with PCNTL disabled

### DIFF
--- a/src/Extension/PhiremockProcess.php
+++ b/src/Extension/PhiremockProcess.php
@@ -69,7 +69,10 @@ class PhiremockProcess
         if ($this->isPcntlEnabled()) {
             $this->process->signal(SIGTERM);
             $this->process->stop(3, SIGKILL);
+            return;
         }
+
+        $this->process->stop(3);
     }
 
     private function setUpProcessCompatibility()


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock-codeception-extension/issues/16

Fix only

Tests result:
```
$ vendor/bin/codecept -c tests/ run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.

Acceptance Tests (1) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
✔ BasicTestCest: Try to test (0.08s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Running exec /opt/phiremock-codeception-extension/vendor/mcustiel/phiremock/bin/phiremock -i 0.0.0.0 -p 18080 -d
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: The Symfony\Component\Process\Process::setEnhanceSigchildCompatibility() method is deprecated since version 3.3 and will be removed in 4.0. Sigchild compatibility will always be enabled. /opt/phiremock-codeception-extension/vendor/symfony/process/Process.php:1276


Time: 3.77 seconds, Memory: 12.00MB

OK (1 test, 1 assertion)
```