### PR TITLE
Allow also codeception in v3.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require" : {
         "php" : ">=5.6",
         "mcustiel/phiremock": "^1.7",
-        "codeception/codeception" : "^2.2",
+        "codeception/codeception" : "^2.2 | ^3.0",
         "symfony/process": ">=2.7.15 <5.0.0"
     }
 }

--- a/tests/tests/acceptance/BasicTestCest.php
+++ b/tests/tests/acceptance/BasicTestCest.php
@@ -92,14 +92,14 @@ class BasicTestCest
         $responseBody = file_get_contents('http://localhost:18080/show-me-the-video');
         $I->assertEquals($responseContents, $responseBody);
     }
-    
+
     public function testGrabRequestsMadeToRemoteService(AcceptanceTester $I)
     {
         $requestBuilder = A::postRequest()->andUrl(Is::equalTo('/some/url'));
         $I->expectARequestToRemoteServiceWithAResponse(
             Phiremock::on($requestBuilder)->then(Respond::withStatusCode(200))
         );
-    
+
         $options = array(
             'http' => array(
                 'header'  => 'Content-Type: application/x-www-form-urlencoded',
@@ -108,16 +108,23 @@ class BasicTestCest
             )
         );
         file_get_contents('http://localhost:18080/some/url', false, stream_context_create($options));
-        
+
         $requests = $I->grabRequestsMadeToRemoteService($requestBuilder);
         $I->assertCount(1, $requests);
-        
+
         $first = reset($requests);
         $I->assertEquals('POST', $first->method);
         $I->assertEquals('a=b', $first->body);
-        $I->assertArraySubset([
+
+        $headers = (array) $first->headers;
+        $expectedSubset = [
             'Host' => ['localhost:18080'],
             'Content-Type' => ['application/x-www-form-urlencoded']
-        ], (array) $first->headers);
+        ];
+
+        foreach ($expectedSubset as $key => $value) {
+            $I->assertArrayHasKey($key, $headers);
+            $I->assertSame($value, $headers[$key]);
+        }
     }
 }


### PR DESCRIPTION
This PR provide a change in composer.json, which will also allow codeception installs in the v3 branch.

Since this will also install PHPUnit in v8 I also had to change a unit test which relayed on a removed method.