### PR TITLE
fixed Codeception ^4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,13 @@
     "license" : "GPL-3.0-or-later",
     "require" : {
         "php" : ">=5.6",
-        "mcustiel/phiremock": "^1.7",
-        "codeception/codeception" : "^2.2 | ^3.0",
-        "symfony/process": ">=2.7.15 <5.0.0"
+        "mcustiel/phiremock": "^1.7.2",
+        "codeception/codeception" : "^2.2 | ^3.0 | ^4.0",
+        "symfony/process": ">=2.7.15 <5.0.0",
+        "codeception/lib-asserts": "^1.1"
+    },
+    "require-dev": {
+        "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-asserts": "^1.1"
     }
 }


### PR DESCRIPTION
made adjustments in composer.json for tests working with `composer update --prefer-stable --prefer-lowest`, fixes https://github.com/mcustiel/phiremock-codeception-extension/issues/36