### PR TITLE
Fix inability to use zero delay

### DIFF
--- a/src/PhiremockExtension/Config.php
+++ b/src/PhiremockExtension/Config.php
@@ -208,7 +208,7 @@ class Config
             return;
         }
 
-        if ($config['start_delay']) {
+        if (is_int($config['start_delay']) && $config['start_delay'] >= 0) {
             $this->delay = (int) $config['start_delay'];
         }
     }


### PR DESCRIPTION
The default config has start_delay as zero, which is skipped over by the if condition due to zero's falseness. Occurs both when not specifying delay_date in the yaml config or when set to zero.

Possibly the use of is_int is more restrictive than necessary given that it would preclude a float that would work, but I think the logic of the start delay implies it should be an integer.