### PR TITLE
Fixed absolute path detection

### DIFF
--- a/src/PhiremockExtension/Path.php
+++ b/src/PhiremockExtension/Path.php
@@ -33,7 +33,7 @@ class Path
 
     public function absoluteOrRelativeToCodeceptionDir(): string
     {
-        if (preg_match('%^(?:[a-z]:\\|/)%', $this->path) === 1) {
+        if (preg_match('~^(?:[a-z]:\\\|/)~i', $this->path) === 1) {
             return $this->path;
         }
         return Configuration::projectDir() . $this->path;

--- a/src/PhiremockExtension/Path.php
+++ b/src/PhiremockExtension/Path.php
@@ -33,7 +33,7 @@ class Path
 
     public function absoluteOrRelativeToCodeceptionDir(): string
     {
-        if (substr($this->path, 0, 1) === '/') {
+        if (preg_match('%^(?:[a-z]:\\|/)%', $this->path) === 1) {
             return $this->path;
         }
         return Configuration::projectDir() . $this->path;


### PR DESCRIPTION
Detected here: https://github.com/mcustiel/phiremock-codeception-module/issues/7
Happening only on windows.