### PR TITLE
Add wait_until_ready config and check if phiremock server is actually running

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Time to wait after Phiremock Server is started before running the tests (used to
 
 **Default:** 0
 
+#### wait_until_ready
+This is more robust alternative to start_delay. It will check if Phiremock Server is actually running before running the tests.
+Note: it depends on Phiremeock Client to be installed via composer (it is used to check the status of Phiremock Server).
+
+**Default:** false
+
+#### wait_until_ready_timeout
+This will be used only if wait_until_ready is set to true. You can specify after how many seconds it will stop checking if Phiremock Server is running.
+
+**Default:** 30
+
 #### expectations_path
 Specifies a directory to search for json files defining expectations to load by default.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ Optionally, you can install Phiremock Server in case you want to have it between
     "mcustiel/phiremock-codeception-extension": "^2.0",
     "mcustiel/phiremock-server": "^1.0",
     "guzzlehttp/guzzle": "^6.0"
+}
 ```
 
 Phiremock server has been made an optional dependency in case you want to run it from a phar file, a global composer dependency or in a docker container, and not have it as a project dependency.
 
+Note: if you are going to use *wait_until_ready* configuration as true, you will also need Phiremock Client installed:
+```json
+"require-dev": {
+    "mcustiel/phiremock-codeception-extension": "^2.0",
+    "mcustiel/phiremock-client": "^1.0"
+}
+```
 ## Configuration
 
 ```yaml
@@ -127,7 +135,7 @@ extensions:
         \Codeception\Extension\Phiremock:
             listen: 127.0.0.1:18080  
             debug: true 
-            start_delay: 1
+            wait_until_ready: true
             expectations_path: /my/expectations/path-1 
             suites: 
                 - acceptance

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ Optionally, you can install Phiremock Server in case you want to have it between
 
 Phiremock server has been made an optional dependency in case you want to run it from a phar file, a global composer dependency or in a docker container, and not have it as a project dependency.
 
-Note: if you are going to use *wait_until_ready* configuration as true, you will also need Phiremock Client installed:
-```json
-"require-dev": {
-    "mcustiel/phiremock-codeception-extension": "^2.0",
-    "mcustiel/phiremock-client": "^1.0"
-}
-```
 ## Configuration
 
 ```yaml
@@ -47,7 +40,8 @@ extensions:
             bin_path: ../vendor/bin # defaults to codeception_dir/../vendor/bin 
             logs_path: /var/log/my_app/tests/logs # defaults to codeception's tests output dir
             debug: true # defaults to false
-            start_delay: 1 # default to 0
+            wait_until_ready: true # defaults to false
+            wait_until_ready_timeout: 15 # defaults to 30
             expectations_path: /my/expectations/path # defaults to tests/_expectations
             server_factory: \My\FactoryClass # defaults to 'default'
             extra_instances: [] # deaults to an empty array
@@ -135,7 +129,6 @@ extensions:
         \Codeception\Extension\Phiremock:
             listen: 127.0.0.1:18080  
             debug: true 
-            wait_until_ready: true
             expectations_path: /my/expectations/path-1 
             suites: 
                 - acceptance

--- a/src/Extension/Phiremock.php
+++ b/src/Extension/Phiremock.php
@@ -22,6 +22,10 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Extension as CodeceptionExtension;
 use Codeception\Suite;
+use Mcustiel\Phiremock\Client\Connection\Host;
+use Mcustiel\Phiremock\Client\Connection\Port;
+use Mcustiel\Phiremock\Client\Connection\Scheme;
+use Mcustiel\Phiremock\Client\Factory;
 use Mcustiel\Phiremock\Codeception\Extension\Config;
 use Mcustiel\Phiremock\Codeception\Extension\PhiremockProcessManager;
 
@@ -68,6 +72,7 @@ class Phiremock extends CodeceptionExtension
             }
         }
         $this->executeDelay();
+        $this->waitUntilReady();
     }
 
     public function stopProcess(): void
@@ -107,5 +112,41 @@ class Phiremock extends CodeceptionExtension
         if (!isset($this->config['logs_path'])) {
             $this->config['logs_path'] = Config::getDefaultLogsPath();
         }
+    }
+
+    private function waitUntilReady(): void
+    {
+        if (!$this->extensionConfig->isWaitUntilReady()) {
+            return;
+        }
+
+        $this->writeln('Waiting until Phiremock is ready...');
+        $client = Factory::createDefault()
+            ->createPhiremockClient(
+                new Host($this->extensionConfig->getInterface()),
+                new Port($this->extensionConfig->getPort()),
+                $this->extensionConfig->isSecure() ? Scheme::createHttps() : Scheme::createHttp()
+            );
+
+        $start = \microtime(true);
+
+        while (true) {
+            try {
+                $client->reset();
+                break;
+            } catch (\Throwable $e) {
+                \sleep(1);
+            }
+
+            $elapsed = (int) (\microtime(true) - $start);
+
+            if ($elapsed > $this->extensionConfig->getWaitUntilReadyTimeout()) {
+                throw new \RuntimeException(
+                    \sprintf('Phiremock failed to start within %d seconds', $this->extensionConfig->getWaitUntilReadyTimeout())
+                );
+            }
+        }
+
+        $this->writeln('Phiremock is ready!');
     }
 }

--- a/src/PhiremockExtension/Config.php
+++ b/src/PhiremockExtension/Config.php
@@ -36,19 +36,23 @@ class Config
     public const DEFAULT_SERVER_FACTORY = 'default';
     public const DEFAULT_EXTRA_INSTANCES = [];
     public const DEFAULT_SUITES = [];
+    public const DEFAULT_WAIT_UNTIL_READY = false;
+    public const DEFAULT_WAIT_UNTIL_READY_TIMEOUT = 30;
 
     public const DEFAULT_CONFIG = [
-        'listen'            => self::DEFAULT_INTERFACE . ':' . self::DEFAULT_PORT,
-        'debug'             => self::DEFAULT_DEBUG_MODE,
-        'start_delay'       => self::DEFAULT_DELAY,
-        'bin_path'          => self::DEFAULT_PHIREMOCK_PATH,
-        'expectations_path' => self::DEFAULT_EXPECTATIONS_PATH,
-        'server_factory'    => self::DEFAULT_SERVER_FACTORY,
-        'certificate'       => self::DEFAULT_CERTIFICATE,
-        'certificate_key'   => self::DEFAULT_CERTIFICATE_KEY,
-        'cert_passphrase'   => self::DEFAULT_CERTIFICATE_PASSPHRASE,
-        'extra_instances'   => self::DEFAULT_EXTRA_INSTANCES,
-        'suites'            => self::DEFAULT_SUITES,
+        'listen'                   => self::DEFAULT_INTERFACE . ':' . self::DEFAULT_PORT,
+        'debug'                    => self::DEFAULT_DEBUG_MODE,
+        'start_delay'              => self::DEFAULT_DELAY,
+        'bin_path'                 => self::DEFAULT_PHIREMOCK_PATH,
+        'expectations_path'        => self::DEFAULT_EXPECTATIONS_PATH,
+        'server_factory'           => self::DEFAULT_SERVER_FACTORY,
+        'certificate'              => self::DEFAULT_CERTIFICATE,
+        'certificate_key'          => self::DEFAULT_CERTIFICATE_KEY,
+        'cert_passphrase'          => self::DEFAULT_CERTIFICATE_PASSPHRASE,
+        'extra_instances'          => self::DEFAULT_EXTRA_INSTANCES,
+        'suites'                   => self::DEFAULT_SUITES,
+        'wait_until_ready'         => self::DEFAULT_WAIT_UNTIL_READY,
+        'wait_until_ready_timeout' => self::DEFAULT_WAIT_UNTIL_READY_TIMEOUT
     ];
 
     /** @var string */
@@ -79,6 +83,10 @@ class Config
     private $suites;
     /** @var callable */
     private $output;
+    /** @var bool */
+    private $waitUntilReady;
+    /** @var int */
+    private $waitUntilReadyTimeout;
 
     /** @throws ConfigurationException */
     public function __construct(array $config, callable $output)
@@ -96,6 +104,8 @@ class Config
         $this->certificatePassphrase = $config['cert_passphrase'];
         $this->initExtraInstances($config);
         $this->suites = $config['suites'];
+        $this->waitUntilReady = (bool) $config['wait_until_ready'];
+        $this->waitUntilReadyTimeout = (int) $config['wait_until_ready_timeout'];
     }
 
     public function getSuites(): array
@@ -166,6 +176,22 @@ class Config
     public function getExtraInstances(): array
     {
         return $this->extraInstances;
+    }
+
+    public function isSecure(): bool
+    {
+        return $this->getCertificatePath() !== null
+            && $this->getCertificateKeyPath() !== null;
+    }
+
+    public function isWaitUntilReady(): bool
+    {
+        return $this->waitUntilReady;
+    }
+
+    public function getWaitUntilReadyTimeout(): int
+    {
+        return $this->waitUntilReadyTimeout;
     }
 
     /** @throws ConfigurationException */

--- a/src/PhiremockExtension/ReadinessChecker/CurlChecker.php
+++ b/src/PhiremockExtension/ReadinessChecker/CurlChecker.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of codeception-phiremock-extension.
+ *
+ * phiremock-codeception-extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * phiremock-codeception-extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with phiremock-codeception-extension.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mcustiel\Phiremock\Codeception\Extension\ReadinessChecker;
+
+use Mcustiel\Phiremock\Codeception\Extension\ReadinessCheckerInterface;
+
+class CurlChecker implements ReadinessCheckerInterface
+{
+    private $url;
+
+    public function __construct(string $url)
+    {
+        $this->url = rtrim($url, '/');
+    }
+
+    public function isReady(): bool
+    {
+        $ch = \curl_init();
+
+        \curl_setopt($ch, CURLOPT_URL,$this->url . '/__phiremock/reset');
+        \curl_setopt($ch, CURLOPT_POST, 1);
+        \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        $output = \curl_exec($ch);
+        \curl_close($ch);
+
+        if ($output === false) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/PhiremockExtension/ReadinessChecker/PhiremockClientChecker.php
+++ b/src/PhiremockExtension/ReadinessChecker/PhiremockClientChecker.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of codeception-phiremock-extension.
+ *
+ * phiremock-codeception-extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * phiremock-codeception-extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with phiremock-codeception-extension.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mcustiel\Phiremock\Codeception\Extension\ReadinessChecker;
+
+use GuzzleHttp\Exception\ConnectException;
+use Mcustiel\Phiremock\Codeception\Extension\ReadinessCheckerInterface;
+use Mcustiel\Phiremock\Client\Phiremock;
+use Psr\Http\Client\ClientExceptionInterface;
+
+class PhiremockClientChecker implements ReadinessCheckerInterface
+{
+    private $client;
+
+    public function __construct(Phiremock $client)
+    {
+        $this->client = $client;
+    }
+
+    public function isReady(): bool
+    {
+        try {
+            $this->client->reset();
+            return true;
+        } catch (ConnectException $e) {}
+
+        return false;
+    }
+}

--- a/src/PhiremockExtension/ReadinessCheckerFactory.php
+++ b/src/PhiremockExtension/ReadinessCheckerFactory.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of codeception-phiremock-extension.
+ *
+ * phiremock-codeception-extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * phiremock-codeception-extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with phiremock-codeception-extension.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mcustiel\Phiremock\Codeception\Extension;
+
+use Mcustiel\Phiremock\Client\Factory;
+use Mcustiel\Phiremock\Client\Connection\Host;
+use Mcustiel\Phiremock\Client\Connection\Port;
+use Mcustiel\Phiremock\Client\Connection\Scheme;
+use Mcustiel\Phiremock\Codeception\Extension\ReadinessChecker\CurlChecker;
+use Mcustiel\Phiremock\Codeception\Extension\ReadinessChecker\PhiremockClientChecker;
+
+class ReadinessCheckerFactory
+{
+    public static function create(string $host, string $port, bool $isSecure): ReadinessCheckerInterface
+    {
+        if (class_exists(Factory::class)) {
+            $phiremockClient = Factory::createDefault()
+                ->createPhiremockClient(
+                    new Host($host),
+                    new Port($port),
+                    $isSecure ? Scheme::createHttps() : Scheme::createHttp()
+                );
+
+            return new PhiremockClientChecker(
+                $phiremockClient
+            );
+        } elseif (extension_loaded('curl')) {
+            $url = 'http' . ($isSecure ? 's' : '')
+                . '://' . $host
+                . ($port !== '' ? ':' . $port : '');
+
+            return new CurlChecker($url);
+        }
+
+        throw new \RuntimeException(
+            'Config wait_until_ready is enabled but no readiness checker can be run. Check if you have Phiremock Client installed or curl extension enabled.'
+        );
+    }
+}

--- a/src/PhiremockExtension/ReadinessCheckerInterface.php
+++ b/src/PhiremockExtension/ReadinessCheckerInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of codeception-phiremock-extension.
+ *
+ * phiremock-codeception-extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * phiremock-codeception-extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with phiremock-codeception-extension.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mcustiel\Phiremock\Codeception\Extension;
+
+interface ReadinessCheckerInterface
+{
+    public function isReady(): bool;
+}


### PR DESCRIPTION
This PR adds:
- new configs: wait_until_ready and wait_until_ready_timeout
- if wait_until_ready is set to true it will use phiremock client reset method to call phiremock server
- if phiremock server does not respond within specified timeout, exception will be thrown
- some updates to README